### PR TITLE
Uninstall Google Sounds from install.sh

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -7,6 +7,7 @@ ui_print "   Vol Up = Yes, Vol Down = No"
 if $VKSEL; then
   ui_print " "
   ui_print "   Enabling boot animation..."
+  pm uninstall -k <com.google.android.soundpicker>
 else
   ui_print " "
   ui_print "   Disabling boot animation..."


### PR DESCRIPTION
Google Sounds causes problems as it displays over System media sounds selection, making unreadable the modifications made by Oxy-ify.
I have tried to send it to terminal with this command. [Source](https://stackoverflow.com/questions/17556750/how-to-uninstall-an-android-app-from-command-line-on-the-device/17556878#17556878)