### PR TITLE
Blacklist Google Pixel devices

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -1,3 +1,21 @@
+if [ -n "$PIXEL" ]; then
+  ui_print " "
+  ui_print "   Oxy-ify doesn't support Google Pixel devices on stock Rom!"
+  ui_print "   DO NOT ATTEMPT TO INSTALL ON STOCK ROM, YOU'LL HAVE A BOOTLOOP"
+  ui_print "   If flashed on a Custom Rom you won't have problems"
+  ui_print "   *******************************************"
+  ui_print "   Are you using a Custom Rom and do you want to install it?"
+  ui_print "   Vol Up = Yes, Vol Down = No"
+  if $FUNCTION; then
+    ui_print " "
+    ui_print "   Ignoring warnings..."
+  else
+    ui_print " "
+    ui_print "   Exiting..."
+    abort
+  fi
+fi
+
 ui_print " "
 ui_print " - Boot Animation Option -"
 ui_print " *******************************************"

--- a/config.sh
+++ b/config.sh
@@ -45,7 +45,7 @@ unity_upgrade() {
 
 # Custom Variables for Install AND Uninstall - Keep everything within this function - runs before uninstall/install
 unity_custom() {
-  : # Remove this if adding to this function
+  PIXEL=$(grep -E "ro.product.manufacturer=Google|ro.product.vendor.brand=Google" $BUILDS)
 }
 
 # Custom Functions for Install AND Uninstall - You can put them here


### PR DESCRIPTION
This is necessary, since it seems Oxy-ify is led to bootloop on Google Pixels.